### PR TITLE
Simple Dockerfile for VegaDNS-UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+README.md
+.git
+.*ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:alpine
+
+ADD . /opt/vegadns
+WORKDIR /opt/vegadns
+
+RUN apk add --update --virtual build-dependancies git bash nodejs \
+  && ./build.sh \
+  && rm -rf node_modules \
+  && apk del build-dependancies
+RUN rm -rf /usr/share/nginx/html/ && \
+  ln -s /opt/vegadns/public /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,5 @@ RUN apk add --update --virtual build-dependancies git bash nodejs \
   && apk del build-dependancies
 RUN rm -rf /usr/share/nginx/html/ && \
   ln -s /opt/vegadns/public /usr/share/nginx/html
+
+CMD ["/opt/vegadns/run.sh"]

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ npm run-script watch
 ```
 
 Then you can point your browser to [http://localhost:8080/webpack-dev-server](http://localhost:8080/webpack-dev-server).  By default, it points at a local API server at http://localhost:5000 (flask test server default).  If you want to change this, uncomment and modify the VegaDNSHost variable in public/index.html.
+
+## Docker container configuration
+
+| env variable | default | description |
+| - | - | - |
+| API_URL | http<i></i>://localhost:5000/ | Sets the location of the VegaDNS-API host. |

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+# Set up API_URL config for UI
+if [ -n "$API_URL" ] ; then
+  sed -ie "s@// var VegaDNSHost = \"http://localhost:5000\";@var VegaDNSHost = \"${API_URL}\";@" /opt/vegadns/public/index.html
+fi
+
+# Let nginx take PID 1
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Run VegaDNS-UI in its own docker container.  If you want to change the API url, uncomment and modify `VegaDNSHost` in public/index.html before building the image.

.dockerignore is just to help get the smallest possible image.